### PR TITLE
Remove integrity check from bootswatch link

### DIFF
--- a/aniauth/templates/base.html
+++ b/aniauth/templates/base.html
@@ -8,7 +8,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
         <!-- Bootstrap CSS -->
-        <link rel="stylesheet" href="https://cdn.rawgit.com/thomaspark/bootswatch/v4/flatly/bootstrap.min.css" integrity="sha384-sWMkWMJ5pqIoUcXfA/+bJ2iWRBD6GWyIzk3itajLe/dRF2gvdOADdXLG9us75jbM" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.rawgit.com/thomaspark/bootswatch/v4/flatly/bootstrap.min.css">
 
         <title>{% block title %}{{ view.title }}{% endblock title %} | ANIAuth</title>
     </head>


### PR DESCRIPTION
It's in alpha at the moment so it changes too often.